### PR TITLE
Input label misplaced inside ngif (#189)

### DIFF
--- a/src/app/checkbox/checkbox.directive.ts
+++ b/src/app/checkbox/checkbox.directive.ts
@@ -44,7 +44,7 @@ export class MzCheckboxDirective extends HandlePropChanges implements OnInit {
     const labelElement = document.createElement('label');
     labelElement.setAttribute('for', this.id);
 
-    this.renderer.invokeElementMethod(this.checkboxContainerElement, 'append', [labelElement]);
+    this.renderer.invokeElementMethod(this.checkboxElement, 'after', [labelElement]);
 
     return $(labelElement);
   }

--- a/src/app/checkbox/checkbox.directive.unit.spec.ts
+++ b/src/app/checkbox/checkbox.directive.unit.spec.ts
@@ -120,15 +120,15 @@ describe('MzCheckboxDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const checkboxId = 'checkbox-id';
-      const mockCheckboxContainerElement = { checkboxContainer: true };
+      const mockCheckboxElement = { checkbox: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', checkboxId);
 
       directive.id = checkboxId;
-      directive.checkboxContainerElement = <any>mockCheckboxContainerElement;
+      directive.checkboxElement = <any>mockCheckboxElement;
       directive.createLabelElement();
 
-      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockCheckboxContainerElement, 'append', [mockLabelElement]);
+      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockCheckboxElement, 'after', [mockLabelElement]);
     });
 
     it('should return the newly created element', () => {

--- a/src/app/input/input.directive.ts
+++ b/src/app/input/input.directive.ts
@@ -79,7 +79,7 @@ export class MzInputDirective extends HandlePropChanges implements OnInit, OnDes
     const labelElement = document.createElement('label');
     labelElement.setAttribute('for', this.id);
 
-    this.renderer.invokeElementMethod(this.inputContainerElement, 'append', [labelElement]);
+    this.renderer.invokeElementMethod(this.inputElement, 'after', [labelElement]);
 
     return $(labelElement);
   }

--- a/src/app/input/input.directive.unit.spec.ts
+++ b/src/app/input/input.directive.unit.spec.ts
@@ -195,15 +195,15 @@ describe('MzInputDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const inputId = 'input-id';
-      const mockInputContainerElement = { inputContainer: true };
+      const mockInputElement = { input: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', inputId);
 
       directive.id = inputId;
-      directive.inputContainerElement = <any>mockInputContainerElement;
+      directive.inputElement = <any>mockInputElement;
       directive.createLabelElement();
 
-      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockInputContainerElement, 'append', [mockLabelElement]);
+      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockInputElement, 'after', [mockLabelElement]);
     });
 
     it('should return the newly created element', () => {

--- a/src/app/radio-button/radio-button.directive.ts
+++ b/src/app/radio-button/radio-button.directive.ts
@@ -44,7 +44,7 @@ export class MzRadioButtonDirective extends HandlePropChanges implements OnInit 
     const labelElement = document.createElement('label');
     labelElement.setAttribute('for', this.id);
 
-    this.renderer.invokeElementMethod(this.inputContainerElement, 'append', [labelElement]);
+    this.renderer.invokeElementMethod(this.inputElement, 'after', [labelElement]);
 
     return $(labelElement);
   }

--- a/src/app/radio-button/radio-button.directive.unit.spec.ts
+++ b/src/app/radio-button/radio-button.directive.unit.spec.ts
@@ -120,15 +120,15 @@ describe('MzRadioButtonDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const inputId = 'input-id';
-      const mockInputContainerElement = { inputContainer: true };
+      const mockRadioInputElement = { input: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', inputId);
 
       directive.id = inputId;
-      directive.inputContainerElement = <any>mockInputContainerElement;
+      directive.inputElement = <any>mockRadioInputElement;
       directive.createLabelElement();
 
-      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockInputContainerElement, 'append', [mockLabelElement]);
+      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockRadioInputElement, 'after', [mockLabelElement]);
     });
 
     it('should return the newly created element', () => {

--- a/src/app/select/select.directive.ts
+++ b/src/app/select/select.directive.ts
@@ -125,7 +125,7 @@ export class MzSelectDirective extends HandlePropChanges implements OnInit, OnDe
     const labelElement = document.createElement('label');
     labelElement.setAttribute('for', this.id);
 
-    this.renderer.invokeElementMethod(this.selectContainerElement, 'append', [labelElement]);
+    this.renderer.invokeElementMethod(this.selectElement, 'after', [labelElement]);
 
     return $(labelElement);
   }

--- a/src/app/select/select.directive.unit.spec.ts
+++ b/src/app/select/select.directive.unit.spec.ts
@@ -320,15 +320,15 @@ describe('MzSelectDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const selectId = 'select-id';
-      const mockSelectContainerElement = { selectContainer: true };
+      const mockSelectElement = { select: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', selectId);
 
       directive.id = selectId;
-      directive.selectContainerElement = <any>mockSelectContainerElement;
+      directive.selectElement = <any>mockSelectElement;
       directive.createLabelElement();
 
-      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockSelectContainerElement, 'append', [mockLabelElement]);
+      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockSelectElement, 'after', [mockLabelElement]);
     });
 
     it('should return the newly created element', () => {

--- a/src/app/textarea/textarea.directive.ts
+++ b/src/app/textarea/textarea.directive.ts
@@ -51,7 +51,7 @@ export class MzTextareaDirective extends HandlePropChanges implements OnInit {
     const labelElement = document.createElement('label');
     labelElement.setAttribute('for', this.id);
 
-    this.renderer.invokeElementMethod(this.textareaContainerElement, 'append', [labelElement]);
+    this.renderer.invokeElementMethod(this.textareaElement, 'after', [labelElement]);
 
     return $(labelElement);
   }

--- a/src/app/textarea/textarea.directive.unit.spec.ts
+++ b/src/app/textarea/textarea.directive.unit.spec.ts
@@ -154,15 +154,15 @@ describe('MzTextareaDirective:unit', () => {
       spyOn(renderer, 'invokeElementMethod');
 
       const textareaId = 'textarea-id';
-      const mockTextareaContainerElement = { textareaContainer: true };
+      const mockTextareaElement = { textarea: true };
       const mockLabelElement = document.createElement('label');
       mockLabelElement.setAttribute('for', textareaId);
 
       directive.id = textareaId;
-      directive.textareaContainerElement = <any>mockTextareaContainerElement;
+      directive.textareaElement = <any>mockTextareaElement;
       directive.createLabelElement();
 
-      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockTextareaContainerElement, 'append', [mockLabelElement]);
+      expect(renderer.invokeElementMethod).toHaveBeenCalledWith(mockTextareaElement, 'after', [mockLabelElement]);
     });
 
     it('should return the newly created element', () => {


### PR DESCRIPTION
* Make sure input label is always right after the input instead of last element of the container

* Fix spacing

* Extend the text input fix to all other input type

* Rename input mock variable to indicate it's a radio button