### PR TITLE
Fix handleDOMEvents to be reattached when select is reinitialized (#199)

### DIFF
--- a/src/app/select/select.directive.ts
+++ b/src/app/select/select.directive.ts
@@ -236,6 +236,8 @@ export class MzSelectDirective extends HandlePropChanges implements OnInit, OnDe
       this.initFilledIn();
     }
 
+    this.handleDOMEvents();
+
     // wait for materialize select to be initialized
     // /!\ race condition warning /!\
     setTimeout(() => this.onUpdate.emit());


### PR DESCRIPTION
* Fix handleDOMEvents to be reattached when select is reinitialized

* Simplify tests for updateMaterialiSelect in MzSelectDirective